### PR TITLE
Fixing broken config for newer mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,10 +4,13 @@ repo_url: 'https://github.com/UniversityOfNottingham/universityofnottingham.gith
 edit_uri: 'edit/source/docs/'
 markdown_extensions:
   - admonition
-  - codehilite(guess_lang=false)
-  - toc(permalink=true)
+  - codehilite:
+      guess_lang: false
+  - toc:
+      permalink: true
   - footnotes
-  - pymdownx.betterem(smart_enable=all)
+  - pymdownx.betterem:
+      smart_enable: all
   - pymdownx.caret
   - pymdownx.critic
   - pymdownx.details
@@ -19,12 +22,13 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.superfences
-  - pymdownx.tasklist(custom_checkbox=true)
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - pymdownx.tilde
 extra:
   repo_icon: github
 
-pages:
+nav:
   - Home: index.md
   - Policies: policies.md
   - Standards:


### PR DESCRIPTION
Updates to mkdocs included breaking changes in configuration, and right now our travis builds just use the latest mkdocs in pip.

This PR fixes our config that was broken due to those changes.

- replaced deprecated `pages` with `nav`
- fixed extensions options format

this will fix builds on #1 and #3 once they merge from upstream