### PR TITLE
changed nlog to serilog

### DIFF
--- a/docs/standards/dotnet/core/approved-technologies.md
+++ b/docs/standards/dotnet/core/approved-technologies.md
@@ -50,7 +50,7 @@
         Renders a string as a Razor View, allowing for rich email templating.
 
 ??? summary "Error Logging"
-    !!! success "NLog"
+    !!! success "SeriLog"
 
 ??? summary "Unit Testing"
     !!! success "XUnit"


### PR DESCRIPTION
We should change from using **NLog** to using **Serilog**.

**NLog 5** is still not out, and `5-beta` and the different minor versions of `4.x` seem to require slightly different approaches to configuring and adding in .NET Core applications.

Add to that that Microsoft seem to slightly change  Program/Startup with each new ASP.NET Core release and it gets very confusing, and the documentation is unclear.

**Serilog** is very widely used, and has a modular approach to logging targets.

- It supports SQL Server, MySQL and other SQL databases, files, console, Azure App Insights, Elastic Search, basically anything you can think of.
- Its current usage documentation is up to date for ASP.NET Core and .NET Core 2.1
- It supports configuration via the `appsettings.json` (i.e. .NET Core Configuration Builder) approach
  - NLog doesn't and requires a separate XML config file, which has to be configured to be copied on Build/Publish
- It's easy and well documented to have its Log table created via EF migrations.

